### PR TITLE
refactor(radar): Stop cacheing scrollTop

### DIFF
--- a/addon/-private/data-view/radar/dynamic-radar.js
+++ b/addon/-private/data-view/radar/dynamic-radar.js
@@ -109,7 +109,6 @@ export default class DynamicRadar extends Radar {
 
     if (totalDelta > 0) {
       this.scrollContainer.scrollTop += totalDelta;
-      this._scrollTop = this.scrollContainer.scrollTop;
     }
   }
 

--- a/addon/-private/data-view/radar/index.js
+++ b/addon/-private/data-view/radar/index.js
@@ -20,7 +20,7 @@ export default class Radar {
     this._scrollTopOffset = null;
 
     this._itemContainer = null;
-    this._scrollContiner = null;
+    this._scrollContainer = null;
 
     this.minHeight = 0;
     this.bufferSize = 0;
@@ -43,7 +43,7 @@ export default class Radar {
     this.renderFromLast = renderFromLast;
 
     this._updateVirtualComponentPool();
-    this._scheduleUpdate();
+    this.scheduleUpdate();
   }
 
   destroy() {
@@ -74,7 +74,7 @@ export default class Radar {
    *
    * @private
    */
-  _scheduleUpdate() {
+  scheduleUpdate() {
     if (!this._nextUpdate) {
       this._nextUpdate = this.schedule('sync', () => {
         this._nextUpdate = null;
@@ -115,29 +115,23 @@ export default class Radar {
     return this._scrollContainer;
   }
 
-  get scrollTop() {
-    return this._scrollTop;
-  }
-
-  set scrollTop(scrollTop) {
-    if (this._scrollTop === scrollTop) {
-      return;
-    }
-
-    this._scrollTop = scrollTop;
-
-    this._scheduleUpdate();
-  }
-
   get scrollTopOffset() {
     if (this._scrollTopOffset === null) {
       const itemContainerTop = this.itemContainer ? this.itemContainer.getBoundingClientRect().top : 0;
       const scrollContainerTop = this.scrollContainer ? this.scrollContainer.getBoundingClientRect().top : 0;
 
-      this._scrollTopOffset = (this.scrollContainer.scrollTop + itemContainerTop) - scrollContainerTop;
+      this._scrollTopOffset = (this.scrollTop + itemContainerTop) - scrollContainerTop;
     }
 
     return this._scrollTopOffset;
+  }
+
+  get scrollTop() {
+    return this.scrollContainer.scrollTop;
+  }
+
+  set scrollTop(scrollTop) {
+    this.scrollContainer.scrollTop = scrollTop;
   }
 
   get visibleTop() {
@@ -280,11 +274,12 @@ export default class Radar {
   prepend(items, numPrepended) {
     this.items = items;
     this._prevFirstItemIndex += numPrepended;
-    this.scrollTop += numPrepended * this.minHeight;
 
     this.schedule('sync', () => {
-      this._scrollContainer.scrollTop = this.scrollTop;
+      this.scrollTop += numPrepended * this.minHeight;
     });
+
+    this.scheduleUpdate();
   }
 
   append(items) {

--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -270,12 +270,12 @@ const VerticalCollection = Component.extend({
   _initializeEventHandlers() {
     this._scrollHandler = ({ top }) => {
       if (this._isEarthquake(top)) {
-        this._radar.scrollTop = top;
+        this._radar.scheduleUpdate();
       }
     };
 
     this._resizeHandler = () => {
-      this._scheduleUpdate();
+      this._initializeRadar();
     };
 
     addScrollHandler(this._scrollContainer, this._scrollHandler);


### PR DESCRIPTION
Sometimes scrollTop can change between the time we schedule a RAF and the time
the RAF occurs, especially in Firefox. Removing the extra caching layer makes
it much easier to guarantee that everything is working correctly